### PR TITLE
Incrémenter le numéro de version à 0.6.11

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.freplay"
        name="FReplay"
-       version="0.6.10"
+       version="0.6.11"
        provider-name="SPM, JUL1EN094, sy6sy2">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+Version 0.6.11
+  -Fixed 6play channels
+  -Support tetesaclaques.tv
+  -Update Gulli
+
 Version 0.6.10
   -Fixed Canal +
   -Renamed iTele to cNews


### PR DESCRIPTION
Des problèmes ont été resolus depuis 0.6.10, en particulier un problème avec M6. J'ai incrémenté le numéro de version de l'add-on pour que les repos comme JUL1EN094 puissent offrir la nouvelle version.